### PR TITLE
Enable manual meta model registration

### DIFF
--- a/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/StandaloneInitializerBuilder.java
+++ b/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/StandaloneInitializerBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import tools.mdsd.library.standalone.initialization.impl.EcoreClassPathDetection;
+import tools.mdsd.library.standalone.initialization.impl.MetaModelRegistrationTask;
 import tools.mdsd.library.standalone.initialization.impl.ProjectURIByClasspathRegistration;
 import tools.mdsd.library.standalone.initialization.impl.StandaloneInitializerImpl;
 
@@ -74,6 +75,28 @@ public class StandaloneInitializerBuilder {
         ProjectURIByClasspathRegistration task = new ProjectURIByClasspathRegistration(classOfProject, projectName,
                 rootFolderName);
         initializationTasks.add(task);
+        return this;
+    }
+
+    /**
+     * Register a meta model by a given project name and a relative path within this project.
+     * 
+     * Callers have to ensure that
+     * <ul>
+     * <li>the given project is registered, e.g. by calling
+     * {@link #registerProjectURI(Class, String)}</li>
+     * <li>either {@link #useEcoreClasspathDetection(boolean)} is used or all prerequisites for
+     * loading the meta model resource are fulfilled</li>
+     * </ul>
+     * 
+     * @param projectName
+     *            The name of the project.
+     * @param relativePath
+     *            The path to the meta model file relative to the project without leading slash.
+     * @return Modified builder instance.
+     */
+    public StandaloneInitializerBuilder registerMetaModel(String projectName, String relativePath) {
+        initializationTasks.add(new MetaModelRegistrationTask(projectName, relativePath));
         return this;
     }
 

--- a/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/core/EclipseProjectScanner.java
+++ b/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/core/EclipseProjectScanner.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import tools.mdsd.library.standalone.initialization.InitializationTask;

--- a/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/impl/MetaModelRegistrationTask.java
+++ b/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/impl/MetaModelRegistrationTask.java
@@ -27,7 +27,7 @@ public class MetaModelRegistrationTask implements InitializationTask {
      * Constructs the task
      * 
      * @param projectName
-     *            The name of the project hosting the profile.
+     *            The name of the project hosting the meta model.
      * @param metaModelPath
      *            The path of the meta model relative to the given project without leading slash.
      */
@@ -48,7 +48,7 @@ public class MetaModelRegistrationTask implements InitializationTask {
                 .get(0);
             queue.add(epackage);
         } catch (WrappedException e) {
-            throw new StandaloneInitializationException("Could not load profile. Please check preconditions.",
+            throw new StandaloneInitializationException("Could not load meta model. Please check preconditions.",
                     e.getCause());
         }
         

--- a/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/impl/MetaModelRegistrationTask.java
+++ b/bundles/tools.mdsd.library.standalone.initialization/src/tools/mdsd/library/standalone/initialization/impl/MetaModelRegistrationTask.java
@@ -1,0 +1,62 @@
+package tools.mdsd.library.standalone.initialization.impl;
+
+import java.util.LinkedList;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.common.util.WrappedException;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.impl.EPackageRegistryImpl;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+
+import tools.mdsd.library.standalone.initialization.InitializationTask;
+import tools.mdsd.library.standalone.initialization.StandaloneInitializationException;
+
+/**
+ * Initilization task for manually registering EMF meta models.
+ * 
+ * This implementation assumes that the project containing the meta model has already been registered
+ * with the EMF registries. Callers have to ensure the proper state of the registries, e.g. by
+ * registering the project with another {@link InitializationTask}.
+ */
+public class MetaModelRegistrationTask implements InitializationTask {
+
+    private final String projectName;
+    private final String metaModelPath;
+
+    /**
+     * Constructs the task
+     * 
+     * @param projectName
+     *            The name of the project hosting the profile.
+     * @param metaModelPath
+     *            The path of the meta model relative to the given project without leading slash.
+     */
+    public MetaModelRegistrationTask(String projectName, String metaModelPath) {
+        this.projectName = projectName;
+        this.metaModelPath = metaModelPath;
+    }
+
+    @Override
+    public void initilizationWithoutPlatform() throws StandaloneInitializationException {
+        var rs = new ResourceSetImpl();
+        var uri = URI.createPlatformPluginURI(String.format("/%s/%s", projectName, metaModelPath), false);
+        
+        var queue = new LinkedList<EPackage>();
+        try {
+            var epackage = (EPackage) rs.getResource(uri, true)
+                .getContents()
+                .get(0);
+            queue.add(epackage);
+        } catch (WrappedException e) {
+            throw new StandaloneInitializationException("Could not load profile. Please check preconditions.",
+                    e.getCause());
+        }
+        
+        while(!queue.isEmpty()) {
+            var epackage = queue.pop();
+            EPackageRegistryImpl.INSTANCE.put(epackage.getNsURI(), epackage);
+            queue.addAll(epackage.getESubpackages());            
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds the ability to manually register a meta model. This should not be necessary in most cases because of the powerful automatic registration already built into the initializer. However, special setups like EMF Profiles that do not properly register meta models via extension points but use some custom logic are not covered by this initialization. Manually registering the profile as meta model is one solution.

Later, we might think of implementing some more powerful logic to automatically discover profiles.